### PR TITLE
Sort channels by number

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -85,7 +85,7 @@ def MainMenu():
         oc = ObjectContainer(title2=L('livetv'))
 
         channels = Tvheadend.Channels()
-        channels.sort(key=lambda channel: channel['number'])
+        channels.sort(key=lambda channel: float(channel['number']))
         maxNum = max(channels, key=lambda channel: channel['number'])['number']
 
         Dict['channels'] = dict()


### PR DESCRIPTION
This fixes single digit channels being incorrectly sorted (channel 5.1 was after 10.1, etc).
