### PR TITLE
Fix stream playback error

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -104,7 +104,7 @@ def MainMenu():
 
 
 @route(PREFIX + '/{channelId}')
-def Channel(channelId, container=False):
+def Channel(channelId, container=False, **kwargs):
     channel = Dict['channels'][channelId]
     epg = Dict['epg'][channelId] if channelId in Dict['epg'] else dict()
 


### PR DESCRIPTION
This branch implements a fix for pgaubatz/TvplexendChannel.bundle#17 by adding a **kwargs parameter to the Channel() function.  This effectively suppresses the error by allowing the extra argument to be passed into the function (but is unused by the function).