### PR TITLE
Channel: Add optional includeBandwidths arg

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -104,7 +104,7 @@ def MainMenu():
 
 
 @route(PREFIX + '/{channelId}')
-def Channel(channelId, container=False):
+def Channel(channelId, container=False, includeBandwidths=None):
     channel = Dict['channels'][channelId]
     epg = Dict['epg'][channelId] if channelId in Dict['epg'] else dict()
 


### PR DESCRIPTION
Hi!

(First time I use TvplexendChannel plugin)

With plexmediaserver .deb 1.5.5.3634-995f1dead on Ubuntu 16.04 I was getting:
2017-06-05 14:41:02,016 (7f90b97fa700) :  CRITICAL (runtime:889) - Exception (most recent call last):
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-995f1dead/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/components/runtime.py", line 843, in handle_request
    result = f(**d)
TypeError: Channel() got an unexpected keyword argument 'includeBandwidths'

The proposed change fixes the plugin for me!

Cheers,
- Loïc Minier